### PR TITLE
Add formula for uncrustify 0.70.1

### DIFF
--- a/uncrustify@0.70.1.rb
+++ b/uncrustify@0.70.1.rb
@@ -1,0 +1,33 @@
+class UncrustifyAT0701 < Formula
+  desc "Source code beautifier"
+  homepage "https://uncrustify.sourceforge.io/"
+  url "https://github.com/uncrustify/uncrustify/archive/uncrustify-0.70.1.tar.gz"
+  sha256 "ad0a7b1f68aa3527d1b89d177d192385fe41b830d46167bde3c3b578e9b0ed06"
+  head "https://github.com/uncrustify/uncrustify.git"
+
+  depends_on "cmake" => :build
+
+  def install
+    mkdir "build" do
+      system "cmake", "..", *std_cmake_args
+      system "make", "install"
+    end
+    doc.install (buildpath/"documentation").children
+  end
+
+  test do
+    (testpath/"t.c").write <<~EOS
+      #include <stdio.h>
+      int main(void) {return 0;}
+    EOS
+    expected = <<~EOS
+      #include <stdio.h>
+      int main(void) {
+      \treturn 0;
+      }
+    EOS
+
+    system "#{bin}/uncrustify", "-c", "#{doc}/htdocs/default.cfg", "t.c"
+    assert_equal expected, File.read("#{testpath}/t.c.uncrustify")
+  end
+end


### PR DESCRIPTION
Formula is taken from commit b81e3cd324efc3d186e879f6d99b924e7fb3f0a6
of the public repository at https://github.com/Homebrew/homebrew-core,
and has the following changes:
- Rename the file to reflect the fixed version.
- Remove the bottle block since the binaries are not available anymore
  in Homebrew's bintray.